### PR TITLE
Add ability to clear content-link-api memory cache (#23)

### DIFF
--- a/content-core/build.gradle
+++ b/content-core/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$versions.appcompat"
     implementation "androidx.core:core-ktx:$versions.androidKtx"
     implementation "com.google.android.material:material:$versions.material"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$versions.ktReflect"
 
     testImplementation "junit:junit:$versions.junit4"
     androidTestImplementation "androidx.test.ext:junit:$versions.junitAndroidExt"

--- a/content-core/src/main/java/com/devgary/contentcore/util/KotlinExt.kt
+++ b/content-core/src/main/java/com/devgary/contentcore/util/KotlinExt.kt
@@ -1,0 +1,27 @@
+package com.devgary.contentcore.util
+
+import kotlin.reflect.KProperty0
+import kotlin.reflect.jvm.isAccessible
+
+/**
+ * Returns true if a lazy property has been initialized or if the property is not lazy.
+ */
+val KProperty0<*>.isLazyInitialized: Boolean
+    get() {
+        // Prevent IllegalAccessException from JVM access check on private properties.
+        val originalAccessLevel = isAccessible
+        isAccessible = true
+        val isLazyInitialized = (getDelegate() as? Lazy<*>)?.isInitialized() ?: true
+        // Reset access level.
+        isAccessible = originalAccessLevel
+        return isLazyInitialized
+    }
+
+/**
+ * Executes [action] if property [isLazyInitialized] is true.
+ */
+fun <T> KProperty0<T>.runIfLazyInitialized(action: () -> Unit) {
+    if (isLazyInitialized) {
+        action()
+    }
+}

--- a/content-core/src/main/java/com/devgary/contentcore/util/LogUtils.kt
+++ b/content-core/src/main/java/com/devgary/contentcore/util/LogUtils.kt
@@ -1,0 +1,21 @@
+package com.devgary.contentcore.util
+
+import android.util.Log
+import com.devgary.contentcore.util.annotations.Hacky
+
+val Any.TAG: String
+    get() {
+        val tag = javaClass.simpleName
+        return if (tag.length <= 23) tag else tag.substring(0, 23)
+    }
+
+/**
+ * Tries to log name of function that is calling [logExecutedFunction]
+ */
+@Hacky
+fun Any.logExecutedFunction(tag: String = TAG) {
+    try {
+        Log.d(tag, "Executed function: ${Thread.currentThread().stackTrace[4].methodName}()")
+    }
+    catch (_: Exception) {}
+}

--- a/content-core/src/main/java/com/devgary/contentcore/util/MiscExt.kt
+++ b/content-core/src/main/java/com/devgary/contentcore/util/MiscExt.kt
@@ -4,12 +4,6 @@ package com.devgary.contentcore.util
  * Miscellaneous extension functions that probably don't need its own class for now
  */
 
-val Any.TAG: String
-    get() {
-        val tag = javaClass.simpleName
-        return if (tag.length <= 23) tag else tag.substring(0, 23)
-    }
-
 /**
  * Shortcut function to return [Class.getSimpleName] of [Class] provided by generic
  */

--- a/content-core/src/main/java/com/devgary/contentcore/util/annotations/Hacky.kt
+++ b/content-core/src/main/java/com/devgary/contentcore/util/annotations/Hacky.kt
@@ -1,0 +1,6 @@
+package com.devgary.contentcore.util.annotations
+
+/**
+ * Signifies that the annotated code is hacky and may not work properly
+ */
+annotation class Hacky

--- a/content-link-api/src/main/java/com/devgary/contentlinkapi/Constants.kt
+++ b/content-link-api/src/main/java/com/devgary/contentlinkapi/Constants.kt
@@ -1,0 +1,7 @@
+package com.devgary.contentlinkapi
+
+class Constants {
+    companion object {
+        const val LRU_CACHE_DEFAULT_SIZE = 20
+    }
+}

--- a/content-link-api/src/main/java/com/devgary/contentlinkapi/components/gfycat/GfycatContentLinkHandler.kt
+++ b/content-link-api/src/main/java/com/devgary/contentlinkapi/components/gfycat/GfycatContentLinkHandler.kt
@@ -3,8 +3,10 @@ package com.devgary.contentlinkapi.components.gfycat
 import com.devgary.contentcore.model.content.components.ContentSource
 import com.devgary.contentcore.model.content.components.ContentType
 import com.devgary.contentcore.model.content.Content
+import com.devgary.contentcore.util.runIfLazyInitialized
 import com.devgary.contentlinkapi.components.gfycat.api.GfycatClient
 import com.devgary.contentlinkapi.components.gfycat.api.GfycatEndpoint
+import com.devgary.contentlinkapi.components.interfaces.ClearableMemory
 import com.devgary.contentlinkapi.content.ContentLinkException
 import com.devgary.contentlinkapi.content.ContentLinkHandler
 import com.devgary.contentlinkapi.util.LinkUtils
@@ -12,8 +14,8 @@ import com.devgary.contentlinkapi.util.LinkUtils
 class GfycatContentLinkHandler(
     private val clientId: String,
     private val clientSecret: String,
-) : ContentLinkHandler {
-    private val gfycatApi: GfycatClient by lazy { 
+) : ContentLinkHandler, ClearableMemory {
+    private val gfycatClient: GfycatClient by lazy { 
         GfycatClient(
             clientId = clientId, 
             clientSecret = clientSecret,
@@ -32,7 +34,7 @@ class GfycatContentLinkHandler(
             throw ContentLinkException("Could not parse GfycatName from url $url")
         }
         
-        val response = gfycatApi.getGfycat(gfycatName)
+        val response = gfycatClient.getGfycat(gfycatName)
         response.let {
             response.mp4Url?.let {
                 return Content(ContentSource.Url(it), ContentType.VIDEO)
@@ -44,4 +46,10 @@ class GfycatContentLinkHandler(
 
     private fun parseGfycatNameFromUrl(url: String): String? =
         LinkUtils.parseAlphabeticalIdFromUrl(url, "gfycat.com/")
+
+    override fun clearMemory() {
+        this::gfycatClient.runIfLazyInitialized {
+            gfycatClient.clearMemory()
+        }
+    }
 }

--- a/content-link-api/src/main/java/com/devgary/contentlinkapi/components/imgur/api/ImgurClient.kt
+++ b/content-link-api/src/main/java/com/devgary/contentlinkapi/components/imgur/api/ImgurClient.kt
@@ -1,24 +1,35 @@
 package com.devgary.contentlinkapi.components.imgur.api
 
 import android.util.Log
+import androidx.collection.LruCache
 import com.devgary.contentcore.util.TAG
 import com.devgary.contentcore.util.name
+import com.devgary.contentcore.util.runIfLazyInitialized
+import com.devgary.contentlinkapi.Constants
 import com.devgary.contentlinkapi.components.imgur.api.model.ImgurAlbum
 
 class ImgurClient(private val imgurEndpoint: ImgurEndpoint) {
-    private val cachedAlbumItems: MutableMap<String, ImgurAlbum> by lazy { HashMap() }
+    private val cachedAlbumResponses: LruCache<String, ImgurAlbum>
+            by lazy { LruCache(/* maxSize = */ Constants.LRU_CACHE_DEFAULT_SIZE) }
 
     suspend fun getImgur(albumId: String): ImgurAlbum {
-        cachedAlbumItems[albumId]?.let {
+        cachedAlbumResponses[albumId]?.let {
             Log.i(TAG, "Returning cached ${name<ImgurAlbum>()} for albumId = $albumId")
             return it
         }
 
         // TODO: Handle if status not success
         imgurEndpoint.getImgurAlbum(albumId).album.also {
-            cachedAlbumItems[albumId] = it
+            cachedAlbumResponses.put(albumId, it)
             Log.i(TAG, "Returning network ${name<ImgurAlbum>()} for albumId = $albumId")
             return it
+        }
+    }
+
+    fun clearMemory() {
+        this::cachedAlbumResponses.runIfLazyInitialized {
+            Log.i(TAG,"Cleared ${cachedAlbumResponses.size()} ${name<ImgurAlbum>()} from memory cache")
+            cachedAlbumResponses.evictAll()
         }
     }
 }

--- a/content-link-api/src/main/java/com/devgary/contentlinkapi/components/interfaces/ClearableMemory.kt
+++ b/content-link-api/src/main/java/com/devgary/contentlinkapi/components/interfaces/ClearableMemory.kt
@@ -1,0 +1,5 @@
+package com.devgary.contentlinkapi.components.interfaces
+
+interface ClearableMemory {
+    fun clearMemory()
+}

--- a/content-link-api/src/main/java/com/devgary/contentlinkapi/components/streamable/StreamableContentLinkHandler.kt
+++ b/content-link-api/src/main/java/com/devgary/contentlinkapi/components/streamable/StreamableContentLinkHandler.kt
@@ -3,14 +3,16 @@ package com.devgary.contentlinkapi.components.streamable
 import com.devgary.contentcore.model.content.components.ContentSource
 import com.devgary.contentcore.model.content.components.ContentType
 import com.devgary.contentcore.model.content.Content
+import com.devgary.contentcore.util.runIfLazyInitialized
+import com.devgary.contentlinkapi.components.interfaces.ClearableMemory
 import com.devgary.contentlinkapi.components.streamable.api.StreamableClient
 import com.devgary.contentlinkapi.components.streamable.api.StreamableEndpoint
 import com.devgary.contentlinkapi.content.ContentLinkException
 import com.devgary.contentlinkapi.content.ContentLinkHandler
 import com.devgary.contentlinkapi.util.LinkUtils
 
-class StreamableContentLinkHandler : ContentLinkHandler {
-    private val streamableApi: StreamableClient by lazy {
+class StreamableContentLinkHandler : ContentLinkHandler, ClearableMemory {
+    private val streamableClient: StreamableClient by lazy {
         StreamableClient(StreamableEndpoint.create())
     }
 
@@ -25,7 +27,7 @@ class StreamableContentLinkHandler : ContentLinkHandler {
             throw ContentLinkException("Could not parse Streamable shortcode from url $url")
         }
         
-        val response = streamableApi.getVideo(shortCodeFromUrl)
+        val response = streamableClient.getVideo(shortCodeFromUrl)
         response.let {
             val video = response.videos
                 .filter { v -> v.url.isNotEmpty() }
@@ -41,4 +43,10 @@ class StreamableContentLinkHandler : ContentLinkHandler {
 
     private fun parseShortcodeFromUrl(url: String): String? =
         LinkUtils.parseAlphanumericIdFromUrl(url, "streamable.com/")
+
+    override fun clearMemory() {
+        this::streamableClient.runIfLazyInitialized { 
+            streamableClient.clearMemory()
+        }
+    }
 }

--- a/content-link-api/src/main/java/com/devgary/contentlinkapi/content/BaseContentLinkHandler.kt
+++ b/content-link-api/src/main/java/com/devgary/contentlinkapi/content/BaseContentLinkHandler.kt
@@ -2,10 +2,12 @@ package com.devgary.contentlinkapi.content
 
 import android.util.Log
 import com.devgary.contentcore.model.content.Content
+import com.devgary.contentcore.util.logExecutedFunction
 import com.devgary.contentcore.util.TAG
 import com.devgary.contentcore.util.name
+import com.devgary.contentlinkapi.components.interfaces.ClearableMemory
 
-abstract class AbstractContentLinkApi : ContentLinkHandler {
+abstract class BaseContentLinkHandler : CompositeContentLinkHandler {
     private val contentHandlers = mutableListOf<ContentLinkHandler>()
 
     init {
@@ -36,5 +38,13 @@ abstract class AbstractContentLinkApi : ContentLinkHandler {
         }
         
         return null
+    }
+
+    override fun clearMemory() {
+        logExecutedFunction()
+        
+        contentHandlers.forEach {
+            (it as? ClearableMemory)?.clearMemory()
+        }
     }
 }

--- a/content-link-api/src/main/java/com/devgary/contentlinkapi/content/CompositeContentLinkHandler.kt
+++ b/content-link-api/src/main/java/com/devgary/contentlinkapi/content/CompositeContentLinkHandler.kt
@@ -1,0 +1,5 @@
+package com.devgary.contentlinkapi.content
+
+import com.devgary.contentlinkapi.components.interfaces.ClearableMemory
+
+interface CompositeContentLinkHandler : ContentLinkHandler, ClearableMemory

--- a/demo/src/main/java/com/devgary/contentviewdemo/DemoActivity.kt
+++ b/demo/src/main/java/com/devgary/contentviewdemo/DemoActivity.kt
@@ -10,7 +10,8 @@ import androidx.lifecycle.lifecycleScope
 import com.devgary.contentlinkapi.components.gfycat.GfycatContentLinkHandler
 import com.devgary.contentlinkapi.components.imgur.ImgurContentLinkHandler
 import com.devgary.contentlinkapi.components.streamable.StreamableContentLinkHandler
-import com.devgary.contentlinkapi.content.AbstractContentLinkApi
+import com.devgary.contentlinkapi.content.BaseContentLinkHandler
+import com.devgary.contentlinkapi.content.CompositeContentLinkHandler
 import com.devgary.contentlinkapi.content.ContentLinkHandler
 import com.devgary.contentviewdemo.databinding.ActivityDemoBinding
 import com.devgary.contentviewdemo.util.cancel
@@ -21,8 +22,8 @@ import kotlinx.coroutines.launch
 class DemoActivity : AppCompatActivity() {
     private lateinit var binding: ActivityDemoBinding
 
-    private val contentLinkApi: ContentLinkHandler by lazy {
-        object : AbstractContentLinkApi() {
+    private val contentLinkHandler: CompositeContentLinkHandler by lazy {
+        object : BaseContentLinkHandler() {
             override fun provideContentHandlers(): List<ContentLinkHandler> {
                 return listOf(
                     GfycatContentLinkHandler(
@@ -72,6 +73,10 @@ class DemoActivity : AppCompatActivity() {
             R.id.menu_streamable -> SampleContent.STREAMABLE_URL
             R.id.menu_gfycat_video -> SampleContent.GFYCAT_URL
             R.id.menu_imgur_album -> SampleContent.IMGUR_ALBUM_GALLERY_URL
+            R.id.menu_clear_memory -> {
+                contentLinkHandler.clearMemory()
+                return true
+            }
             else -> return super.onOptionsItemSelected(item)
         }.let { url ->
             showContent(url)
@@ -83,7 +88,7 @@ class DemoActivity : AppCompatActivity() {
         getContentJob.cancel()
         binding.contentview.setViewVisibility(View.GONE)
         getContentJob = lifecycleScope.launch(coroutineExceptionHandler) {
-            contentLinkApi.getContent(url)?.let { content ->
+            contentLinkHandler.getContent(url)?.let { content ->
                 binding.contentview.showContent(content)
             }
         }

--- a/demo/src/main/res/menu/menu_demo.xml
+++ b/demo/src/main/res/menu/menu_demo.xml
@@ -42,4 +42,10 @@
         app:showAsAction="never"
         android:title="Imgur Album Url">
     </item>
+
+    <item
+        android:id="@+id/menu_clear_memory"
+        app:showAsAction="never"
+        android:title="Clear Memory">
+    </item>
 </menu>

--- a/versions.gradle
+++ b/versions.gradle
@@ -3,6 +3,8 @@ ext.versions = [
         targetSdk:                33,
         compileSdk:               33,
         
+        ktReflect                 : '1.7.10',
+        
         appcompat                 : '1.5.0',
         androidKtx                : '1.8.0',
         constraintlayout          : '2.1.4',


### PR DESCRIPTION
- Add ClearableMemory interface to signify ability to clear memory
- Switch cached api responses holder from Map to LruCache

Closes #23