### PR TITLE
Add support for Streamable links that don't have shortCode (#35)

### DIFF
--- a/content-core/src/main/java/com/devgary/contentcore/util/StringExt.kt
+++ b/content-core/src/main/java/com/devgary/contentcore/util/StringExt.kt
@@ -15,3 +15,10 @@ fun String?.equalsIgnoreCase(value: String): Boolean {
 fun String.containsIgnoreCase(value: String): Boolean {
     return this.contains(value, ignoreCase = true)
 }
+
+/**
+ * Return null if string [isNullOrBlank], otherwise returns string
+ */
+fun String?.nullIfBlank(): String? {
+    return if (this.isNullOrBlank()) null else this
+}

--- a/content-link-api/src/main/java/com/devgary/contentlinkapi/components/streamable/StreamableContentLinkHandler.kt
+++ b/content-link-api/src/main/java/com/devgary/contentlinkapi/components/streamable/StreamableContentLinkHandler.kt
@@ -3,13 +3,14 @@ package com.devgary.contentlinkapi.components.streamable
 import com.devgary.contentcore.model.content.components.ContentSource
 import com.devgary.contentcore.model.content.components.ContentType
 import com.devgary.contentcore.model.content.Content
+import com.devgary.contentcore.util.equalsIgnoreCase
 import com.devgary.contentcore.util.runIfLazyInitialized
 import com.devgary.contentlinkapi.components.interfaces.ClearableMemory
 import com.devgary.contentlinkapi.components.streamable.api.StreamableClient
 import com.devgary.contentlinkapi.components.streamable.api.StreamableEndpoint
 import com.devgary.contentlinkapi.content.ContentLinkException
 import com.devgary.contentlinkapi.content.ContentLinkHandler
-import com.devgary.contentlinkapi.util.LinkUtils
+import com.devgary.contentlinkapi.util.LinkUtils.parseDomainFromUrl
 
 class StreamableContentLinkHandler : ContentLinkHandler, ClearableMemory {
     private val streamableClient: StreamableClient by lazy {
@@ -17,24 +18,27 @@ class StreamableContentLinkHandler : ContentLinkHandler, ClearableMemory {
     }
 
     override fun canHandleLink(url: String): Boolean {
-        return parseShortcodeFromUrl(url).isNullOrEmpty().not()
+        return url.parseDomainFromUrl().equalsIgnoreCase("streamable.com")
     }
 
     override suspend fun getContent(url: String): Content {
         val shortCodeFromUrl = parseShortcodeFromUrl(url)
         
-        if (shortCodeFromUrl.isNullOrEmpty()) {
-            throw ContentLinkException("Could not parse Streamable shortcode from url $url")
-        }
-        
-        val response = streamableClient.getVideo(shortCodeFromUrl)
-        response.let {
-            val video = response.videos
-                .filter { v -> v.url.isNotEmpty() }
-                .minByOrNull { v -> v.bitrate }
+        if (!shortCodeFromUrl.isNullOrEmpty()) {
+            val response = streamableClient.getVideo(shortCodeFromUrl)
+            response.let {
+                val video = response.videos
+                    .filter { v -> v.url.isNotEmpty() }
+                    .minByOrNull { v -> v.bitrate }
 
-            video?.let {
-                return Content(ContentSource.Url(video.url), ContentType.VIDEO)
+                video?.let {
+                    return Content(ContentSource.Url(video.url), ContentType.VIDEO)
+                }
+            }
+        }
+        else {
+            streamableClient.parseVideoUrlFromWebpage(url)?.let { 
+                return Content(ContentSource.Url(it), ContentType.VIDEO)
             }
         }
 

--- a/content-link-api/src/main/java/com/devgary/contentlinkapi/components/streamable/api/StreamableClient.kt
+++ b/content-link-api/src/main/java/com/devgary/contentlinkapi/components/streamable/api/StreamableClient.kt
@@ -2,11 +2,10 @@ package com.devgary.contentlinkapi.components.streamable.api
 
 import android.util.Log
 import androidx.collection.LruCache
-import com.devgary.contentcore.util.TAG
-import com.devgary.contentcore.util.name
-import com.devgary.contentcore.util.runIfLazyInitialized
+import com.devgary.contentcore.util.*
 import com.devgary.contentlinkapi.Constants
 import com.devgary.contentlinkapi.components.ApiException
+import com.devgary.contentlinkapi.components.webpageparser.WebpageParser
 import com.devgary.contentlinkapi.components.streamable.api.model.StreamableVideoResponse
 
 class StreamableClient(private val streamableEndpoint: StreamableEndpoint) {
@@ -30,7 +29,13 @@ class StreamableClient(private val streamableEndpoint: StreamableEndpoint) {
         cachedStreamableVideoResponses.put(shortCode, response)
         return response
     }
-    
+
+    suspend fun parseVideoUrlFromWebpage(url: String): String? {
+        val videoUrl = WebpageParser.parseVideoUrlFromWebpage(url)
+        
+        return videoUrl.nullIfBlank()
+    }
+
     fun clearMemory() {
         this::cachedStreamableVideoResponses.runIfLazyInitialized {
             Log.i(TAG,"Cleared ${cachedStreamableVideoResponses.size()} ${name<StreamableVideoResponse>()} from memory cache")

--- a/content-link-api/src/main/java/com/devgary/contentlinkapi/components/webpageparser/WebpageParser.kt
+++ b/content-link-api/src/main/java/com/devgary/contentlinkapi/components/webpageparser/WebpageParser.kt
@@ -1,0 +1,34 @@
+package com.devgary.contentlinkapi.components.webpageparser
+
+import com.devgary.contentcore.util.nullIfBlank
+import com.devgary.contentlinkapi.util.HttpBodyParsingUtils.parseFirstVideoElementSrc
+import com.devgary.contentlinkapi.util.okhttp.suspend.executeAsSuspend
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+object WebpageParser {
+    /**
+     * Makes Http Request to [url] and parses webpage response body for a video url
+     */
+    suspend fun parseVideoUrlFromWebpage(url: String): String? {
+        val responseBody = getWebpageSuccessResponseBody(url)
+        val videoUrl = responseBody?.parseFirstVideoElementSrc()
+
+        return videoUrl.nullIfBlank()
+    }
+
+    private suspend fun getWebpageSuccessResponseBody(url: String): String? {
+        val client = OkHttpClient()
+        val request = Request.Builder()
+            .url(url)
+            .build()
+
+        client.newCall(request).executeAsSuspend().let { response ->
+            if (response.isSuccessful) {
+                return response.body()?.string()
+            }
+        }
+
+        return null
+    }
+}

--- a/content-link-api/src/main/java/com/devgary/contentlinkapi/util/HttpBodyParsingUtils.kt
+++ b/content-link-api/src/main/java/com/devgary/contentlinkapi/util/HttpBodyParsingUtils.kt
@@ -1,0 +1,25 @@
+package com.devgary.contentlinkapi.util
+
+/**
+ * Util functions for parsing Http response body
+ * 
+ * An alternative is to use something like Jsoup but for simple extraction, string manipulation
+ * is faster as Jsoup has to parse the entire body first before being able to query it
+ */
+object HttpBodyParsingUtils {
+
+    /**
+     * Tries to parse src attribute from first &lt;video&gt; element in response body string
+     */
+    fun String.parseFirstVideoElementSrc(): String? {
+        try {
+            return this
+                .substringAfter("<video")
+                .substringAfter("src=\"")
+                .substringBefore("\"")
+        }
+        catch (_: Exception) {}
+        
+        return null
+    }
+}

--- a/content-link-api/src/main/java/com/devgary/contentlinkapi/util/okhttp/suspend/ContinuationCallback.kt
+++ b/content-link-api/src/main/java/com/devgary/contentlinkapi/util/okhttp/suspend/ContinuationCallback.kt
@@ -1,0 +1,33 @@
+package com.devgary.contentlinkapi.util.okhttp.suspend
+
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CompletionHandler
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Response
+import java.io.IOException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/** @see Call.executeAsSuspend */
+internal class ContinuationCallback(
+    private val call: Call,
+    private val continuation: CancellableContinuation<Response>
+) : Callback, CompletionHandler {
+
+    override fun onResponse(call: Call, response: Response) {
+        continuation.resume(response)
+    }
+
+    override fun onFailure(call: Call, e: IOException) {
+        if (!call.isCanceled) {
+            continuation.resumeWithException(e)
+        }
+    }
+
+    override fun invoke(cause: Throwable?) {
+        try {
+            call.cancel()
+        } catch (_: Throwable) {}
+    }
+}

--- a/content-link-api/src/main/java/com/devgary/contentlinkapi/util/okhttp/suspend/OkHttpSuspend.kt
+++ b/content-link-api/src/main/java/com/devgary/contentlinkapi/util/okhttp/suspend/OkHttpSuspend.kt
@@ -1,0 +1,18 @@
+package com.devgary.contentlinkapi.util.okhttp.suspend
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Response
+
+/**
+ * Executes OkHttp call as a suspend function
+ * 
+ * @see <a href="https://github.com/coil-kt/coil/blob/0af5fe016971ba54518a24c709feea3a1fc075eb/coil-base/src/main/java/coil/util/Extensions.kt#L45-L51">Source from Coil lib</a>
+ */
+internal suspend inline fun Call.executeAsSuspend(): Response {
+    return suspendCancellableCoroutine { continuation ->
+        val callback = ContinuationCallback(this, continuation)
+        enqueue(callback)
+        continuation.invokeOnCancellation(callback)
+    }
+}

--- a/demo/src/main/java/com/devgary/contentviewdemo/DemoActivity.kt
+++ b/demo/src/main/java/com/devgary/contentviewdemo/DemoActivity.kt
@@ -72,6 +72,7 @@ class DemoActivity : AppCompatActivity() {
             R.id.menu_gif -> SampleContent.GIF_CONTENT
             R.id.menu_video -> SampleContent.MP4_VIDEO_CONTENT
             R.id.menu_streamable -> SampleContent.STREAMABLE.BASIC_URL 
+            R.id.menu_streamable_parse_webpage -> SampleContent.STREAMABLE.HLS_URL 
             R.id.menu_gfycat_video -> SampleContent.GFYCAT_URL
             R.id.menu_imgur_album -> SampleContent.IMGUR_ALBUM_GALLERY_URL
             R.id.menu_clear_memory -> {

--- a/demo/src/main/res/menu/menu_demo.xml
+++ b/demo/src/main/res/menu/menu_demo.xml
@@ -2,9 +2,15 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/menu_clear_memory"
+        app:showAsAction="never"
+        android:title="Clear Memory">
+    </item>
+    
+    <item
         android:id="@+id/menu_image"
         app:showAsAction="never"
-        android:title="Image Url">
+        android:title="Image Url (Direct)">
     </item>
 
     <item
@@ -16,36 +22,36 @@
     <item
         android:id="@+id/menu_gif"
         app:showAsAction="never"
-        android:title="Gif Url">
+        android:title="Gif Url (Direct)">
     </item>
 
     <item
         android:id="@+id/menu_video"
         app:showAsAction="never"
-        android:title="Video Url">
+        android:title="Video Url (Direct)">
     </item>
 
     <item
         android:id="@+id/menu_streamable"
         app:showAsAction="never"
-        android:title="Streamable Url">
+        android:title="Streamable Url (API)">
+    </item>
+    
+    <item
+        android:id="@+id/menu_streamable_parse_webpage"
+        app:showAsAction="never"
+        android:title="Streamable Url (Parse Webpage)">
     </item>
     
     <item
         android:id="@+id/menu_gfycat_video"
         app:showAsAction="never"
-        android:title="Gfycat Url">
+        android:title="Gfycat Url (API)">
     </item>  
     
     <item
         android:id="@+id/menu_imgur_album"
         app:showAsAction="never"
-        android:title="Imgur Album Url">
-    </item>
-
-    <item
-        android:id="@+id/menu_clear_memory"
-        app:showAsAction="never"
-        android:title="Clear Memory">
+        android:title="Imgur Album Url (API)">
     </item>
 </menu>

--- a/test-core/src/main/java/com/devgary/testcore/SampleContent.kt
+++ b/test-core/src/main/java/com/devgary/testcore/SampleContent.kt
@@ -9,7 +9,6 @@ object SampleContent {
     val GIF_CONTENT = "https://c.tenor.com/VVOA7SCKgmkAAAAM/test.gif"
     val MP4_VIDEO_CONTENT = "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/720/Big_Buck_Bunny_720_10s_30MB.mp4"
     
-    val STREAMABLE_URL = "https://streamable.com/hwa6l"
     val GFYCAT_URL = "https://gfycat.com/foolishcompetentaegeancat-computer-working-laptop-work-cat"
     val IMGUR_ALBUM_GALLERY_URL = "https://imgur.com/gallery/EH7seB9"
     


### PR DESCRIPTION
Make an HTTP call to the webpage and then parse the webpage body for <video> element

Closes #35